### PR TITLE
Added format and from_str for raw varient to dtos 

### DIFF
--- a/divoom/src/dto/divoom_dto_common.rs
+++ b/divoom/src/dto/divoom_dto_common.rs
@@ -1,17 +1,17 @@
 macro_rules! impl_divoom_dto_enum_traits {
-    ($dto_name:ty, $($enum_value:ident: $enum_string:literal),*) => (
+    ($dto_name:ident, $($enum_value:ident: $enum_string:literal),*) => (
         impl FromStr for $dto_name {
             type Err = String;
             fn from_str(v: &str) -> Result<Self, Self::Err> {
                 match v {
                 $(
-                    $enum_string => Ok(<$dto_name>::$enum_value),
+                    $enum_string => Ok($dto_name::$enum_value),
                 )*
                     _ => {
                         let parsed = v
                             .parse::<i32>()
                             .map_err(|x| format!("Invalid value for {}: {}", stringify!($dto_name), x))?;
-                        Ok(<$dto_name>::Raw(parsed))
+                        Ok($dto_name::Raw(parsed))
                     }
                 }
             }
@@ -21,20 +21,11 @@ macro_rules! impl_divoom_dto_enum_traits {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 match self {
                 $(
-                    <$dto_name>::$enum_value => { return write!(f, "{}", $enum_string); },
+                    $dto_name::$enum_value => { return write!(f, "{}", $enum_string); },
                 )*
-                    // error[E0658]: usage of qualified paths in this context is experimental
-                    // <$dto_name>::Raw(n) => write!(f, "{}", n),
+                    $dto_name::Raw(n) => { return write!(f, "{}", n); },
                     _ => {}
                 }
-
-                // error[E0658]: usage of qualified paths in this context is experimental
-                // if let <$dto_name>::Raw(n) = self {
-                // // Or if let <$dto_name>::Raw(_) = self {
-                //     write!(f, "{}", n)
-                // }
-                // :(
-
                 panic!("Unsupported value! Please avoid using Raw if possible.");
             }
         }


### PR DESCRIPTION
It turns out changing `$dto_name:ty` to `$dto_name:ident` makes rustc 😊 

here is what's being generated from the macro for `ChannelType::Raw`:
```rust
                DivoomChannelType::Raw(n) => {
                    return {
                        let result = f.write_fmt(::core::fmt::Arguments::new_v1(
                            &[""],
                            &[::core::fmt::ArgumentV1::new_display(&n)],
                        ));
                        result
                    }
                }
```

Signed-off-by: Jiaxiao Zhou <jiazho@microsoft.com>